### PR TITLE
Updated application.yaml

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,8 +14,8 @@ server:
 
 spring:
   servlet:
-    multipart.max-file-size: 100MB
-    multipart.max-request-size: 100MB
+    multipart.max-file-size: 2048MB
+    multipart.max-request-size: 2048MB
 
 
 # tika configuration


### PR DESCRIPTION
Realistic values should be used for the max-file-size settings, since many institutions would probably use this on images and documents bigger than 100MB we should increase the default limit to at least 2048MB.